### PR TITLE
[ds248x] Support for DS2484 Single-Channel 1-Wire Master

### DIFF
--- a/esphome/components/ds248x/__init__.py
+++ b/esphome/components/ds248x/__init__.py
@@ -24,6 +24,7 @@ ds248xType = ds248x_ns.enum("DS248xType", is_class=True)
 DS248X_TYPES = {
     "ds2482-100": ds248xType.DS2482_100,
     "ds2482-800": ds248xType.DS2482_800,
+    "ds2484" : ds248xType.DS2484,
 }
 
 

--- a/esphome/components/ds248x/ds248x.cpp
+++ b/esphome/components/ds248x/ds248x.cpp
@@ -180,6 +180,10 @@ void DS248xComponent::dump_config() {
       ESP_LOGCONFIG(TAG, "  Type: DS2482-800");
       break;
   }
+    case DS248xType::DS2484:
+      ESP_LOGCONFIG(TAG, "  Type: DS2484");
+      break;
+  }
 
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication with DS248x failed!");
@@ -211,7 +215,7 @@ void DS248xComponent::dump_config() {
       ESP_LOGCONFIG(TAG, "    Resolution: %u", sensor->get_resolution());
     }
   }
-
+  
   // DS2482-800
   if (this->ds248x_type_ == DS248xType::DS2482_800) {
     for (channel = 0; channel < NBR_CHANNELS; channel++) {
@@ -230,6 +234,23 @@ void DS248xComponent::dump_config() {
       }
     }
   }
+
+  // DS2484 Single-Channel 1-Wire Master
+  if (this->ds248x_type_ == DS248xType::DS2484) {
+    for (auto *sensor : this->sensors_) {
+      LOG_SENSOR("  ", "Device", sensor);
+      if (sensor->get_index().has_value()) {
+        ESP_LOGCONFIG(TAG, "    Index %u", *sensor->get_index());
+        if (*sensor->get_index() >= this->found_sensors_.size()) {
+          ESP_LOGE(TAG, "Couldn't find sensor by index - not connected. Proceeding without it.");
+          continue;
+        }
+      }
+      ESP_LOGCONFIG(TAG, "    Address: %s", sensor->get_address_name().c_str());
+      ESP_LOGCONFIG(TAG, "    Channel: %u", sensor->get_channel());
+      ESP_LOGCONFIG(TAG, "    Resolution: %u", sensor->get_resolution());
+    }
+  }
 }
 
 void DS248xComponent::register_sensor(DS248xTemperatureSensor *sensor) {
@@ -244,6 +265,11 @@ void DS248xComponent::register_sensor(DS248xTemperatureSensor *sensor) {
   if (this->ds248x_type_ == DS248xType::DS2482_800) {
     this->channel_sensors_[sensor->get_channel()].push_back(sensor);
   }
+  
+  // DS2484 Single-Channel 1-Wire Master
+  if (this->ds248x_type_ == DS248xType::DS2484) {
+    this->channel_sensors_[0].push_back(sensor);
+  }  
 }
 
 void DS248xComponent::update() {

--- a/esphome/components/ds248x/ds248x.cpp
+++ b/esphome/components/ds248x/ds248x.cpp
@@ -74,7 +74,10 @@ void DS248xComponent::setup() {
     this->sleep_pin_->pin_mode(esphome::gpio::FLAG_OUTPUT);
   }
 
-  if (this->ds248x_type_ == DS248xType::DS2482_100) {
+  // DS2482-100 or DS2484
+  if (this->ds248x_type_ == DS248xType::DS2482_100 ||
+      this->ds248x_type_ == DS248xType::DS2484)
+  {
     // Reset
     this->reset_hub_();
     address = 0;
@@ -122,8 +125,10 @@ void DS248xComponent::setup() {
     this->found_channel_sensors_.push_back(channel);
   }
 
-  // DS2482_100
-  if (this->ds248x_type_ == DS248xType::DS2482_100) {
+  // DS2482-100 or DS2484
+  if (this->ds248x_type_ == DS248xType::DS2482_100 ||
+      this->ds248x_type_ == DS248xType::DS2482_100)
+  {
     for (auto *sensor : this->sensors_) {
       if (sensor->get_index().has_value()) {
         if (*sensor->get_index() >= this->found_sensors_.size()) {
@@ -198,8 +203,10 @@ void DS248xComponent::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
 
-  // DS2482-100
-  if (this->ds248x_type_ == DS248xType::DS2482_100) {
+  // DS2482-100 or DS2484
+  if (this->ds248x_type_ == DS248xType::DS2482_100 ||
+     this->ds248x_type_ == DS248xType::DS2484)
+  {
     for (auto *sensor : this->sensors_) {
       LOG_SENSOR("  ", "Device", sensor);
       if (sensor->get_index().has_value()) {
@@ -233,30 +240,15 @@ void DS248xComponent::dump_config() {
       }
     }
   }
-
-  // DS2484 Single-Channel 1-Wire Master
-  if (this->ds248x_type_ == DS248xType::DS2484) {
-    for (auto *sensor : this->sensors_) {
-      LOG_SENSOR("  ", "Device", sensor);
-      if (sensor->get_index().has_value()) {
-        ESP_LOGCONFIG(TAG, "    Index %u", *sensor->get_index());
-        if (*sensor->get_index() >= this->found_sensors_.size()) {
-          ESP_LOGE(TAG, "Couldn't find sensor by index - not connected. Proceeding without it.");
-          continue;
-        }
-      }
-      ESP_LOGCONFIG(TAG, "    Address: %s", sensor->get_address_name().c_str());
-      ESP_LOGCONFIG(TAG, "    Channel: %u", sensor->get_channel());
-      ESP_LOGCONFIG(TAG, "    Resolution: %u", sensor->get_resolution());
-    }
-  }
 }
 
 void DS248xComponent::register_sensor(DS248xTemperatureSensor *sensor) {
   this->sensors_.push_back(sensor);
 
   // DS2482-100
-  if (this->ds248x_type_ == DS248xType::DS2482_100) {
+  if (this->ds248x_type_ == DS248xType::DS2482_100 ||
+      this->ds248x_type_ == DS248xType::DS2484)
+  {
     this->channel_sensors_[0].push_back(sensor);
   }
 
@@ -264,11 +256,6 @@ void DS248xComponent::register_sensor(DS248xTemperatureSensor *sensor) {
   if (this->ds248x_type_ == DS248xType::DS2482_800) {
     this->channel_sensors_[sensor->get_channel()].push_back(sensor);
   }
-  
-  // DS2484 Single-Channel 1-Wire Master
-  if (this->ds248x_type_ == DS248xType::DS2484) {
-    this->channel_sensors_[0].push_back(sensor);
-  }  
 }
 
 void DS248xComponent::update() {

--- a/esphome/components/ds248x/ds248x.cpp
+++ b/esphome/components/ds248x/ds248x.cpp
@@ -174,7 +174,7 @@ void DS248xComponent::dump_config() {
 
   switch (this->ds248x_type_) {
     case DS248xType::DS2482_100:
-      ESP_LOGCONFIG(TAG, "  Type: DD2482-100");
+      ESP_LOGCONFIG(TAG, "  Type: DS2482-100");
       break;
     case DS248xType::DS2482_800:
       ESP_LOGCONFIG(TAG, "  Type: DS2482-800");

--- a/esphome/components/ds248x/ds248x.cpp
+++ b/esphome/components/ds248x/ds248x.cpp
@@ -179,7 +179,6 @@ void DS248xComponent::dump_config() {
     case DS248xType::DS2482_800:
       ESP_LOGCONFIG(TAG, "  Type: DS2482-800");
       break;
-  }
     case DS248xType::DS2484:
       ESP_LOGCONFIG(TAG, "  Type: DS2484");
       break;

--- a/esphome/components/ds248x/ds248x.h
+++ b/esphome/components/ds248x/ds248x.h
@@ -15,6 +15,7 @@ namespace ds248x {
 enum class DS248xType : int {
   DS2482_100 = 0,
   DS2482_800 = 1,
+  DS2484 = 2,
 };
 
 class DS248xTemperatureSensor;


### PR DESCRIPTION
# What does this implement/fix?

Add support for DS2484 Single-Channel 1-Wire Master:
https://www.analog.com/media/en/technical-documentation/data-sheets/ds2484.pdf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
ds248x:
    type: ds2484
    address: 0x18
    active_pullup: false
    strong_pullup: false
    bus_sleep: false
    update_interval: 10s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
